### PR TITLE
super basic keystone support in place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC=gcc
 CFLAGS=-g3 -O0 -Wall -DASSEMBLER=\"$(AS)\"
 SRCS=main.c asrepl_commands.c asrepl.c
 OBJS=$(SRCS:.c=.o)
-LDFLAGS=-lreadline 
+LDFLAGS=-lreadline -lkeystone 
 
 all: $(APP)
 


### PR DESCRIPTION
Replaced the native assembler with Keystone (hard-coded to x86_64 mode).  Probably want to make this a Makefile flag for users that wish to avoid the additional dependency.