### PR TITLE
ignore tmp binaries in version control and assign assembler handle if…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Makefile
+config.h
+.asrepl*

--- a/assembler.c
+++ b/assembler.c
@@ -205,7 +205,7 @@ static _Bool keystone_init(assembler_t *as)
     if(err != KS_ERR_OK)
       return false;
 
-    if (!as->handle)
+    if (as->handle)
       return false;
 
     as->handle = (assembler_h)ks;


### PR DESCRIPTION
… none already exists